### PR TITLE
Bug/multithread lock

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,4 +6,6 @@ exclude_lines =
 omit =
     .venv/*
     tests/*
+    scripts/*
     setup.py
+    check_release.py

--- a/planchet/core.py
+++ b/planchet/core.py
@@ -141,8 +141,15 @@ class Job:
         reader_name = record['reader_name']
         writer_name = record['writer_name']
         metadata = record['metadata']
-        reader: Callable = getattr(io, reader_name)(metadata)
-        writer: Callable = getattr(io, writer_name)(metadata)
+        reader: Callable = get_io_object(reader_name, metadata)
+        writer: Callable = get_io_object(writer_name, metadata)
         mode: str = record['mode']
         job: Job = Job(job_name, reader, writer, ledger, mode)
         return job
+
+
+def get_io_object(name, metadata):
+    try:
+        return getattr(io, name)(metadata)
+    except AttributeError:
+        return None

--- a/planchet/io.py
+++ b/planchet/io.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import threading
 from typing import Dict, List, Iterator, Union
 
 import pandas as pd
@@ -10,7 +11,6 @@ from .util import red
 
 
 class CsvReader:
-
     def __init__(self, meta_data: Dict):
         self.file_path: str = meta_data['input_file_path']
         self.chunk_size: int = int(meta_data.get('chunk_size', 100))
@@ -19,6 +19,7 @@ class CsvReader:
                         chunksize=self.chunk_size)
         self.df_iter = self._next_fp_it()
         self.idx = 0
+        self.lock = threading.Lock()
 
     def _next_fp_it(self):
         return next(self.file_iter).iterrows()
@@ -35,40 +36,41 @@ class CsvReader:
                 break
 
     def __call__(self, batch_size: int):
-        batch: List = []
-        for id_, row in self._iterator():
-            batch.append((id_, (*row,)))
-            if len(batch) == batch_size:
-                break
-        return batch
+        with self.lock:
+            batch: List = []
+            for id_, row in self._iterator():
+                batch.append((id_, (*row,)))
+                if len(batch) == batch_size:
+                    break
+            return batch
 
 
 class JsonlReader:
-
     def __init__(self, meta_data: Dict):
         self.id_ = 0
         self.iter: Iterator = open(meta_data['input_file_path'])
+        self.lock = threading.Lock()
 
     def __call__(self, batch_size: int):
-        batch: List = []
-        for id_, line in enumerate(self.iter, start=self.id_):
-            try:
-                jsn: Union[Dict, List] = json.loads(line)
-            except json.JSONDecodeError:
-                logging.error(red(f'Could not parse JSON: {line}'))
-                continue
-            batch.append((id_, jsn))
-            self.id_ = id_ + 1
-            if len(batch) == batch_size:
-                break
-        return batch
+        with self.lock:
+            batch: List = []
+            for id_, line in enumerate(self.iter, start=self.id_):
+                try:
+                    jsn: Union[Dict, List] = json.loads(line)
+                except json.JSONDecodeError:
+                    logging.error(red(f'Could not parse JSON: {line}'))
+                    continue
+                batch.append((id_, jsn))
+                self.id_ = id_ + 1
+                if len(batch) == batch_size:
+                    break
+            return batch
 
 
 class CsvWriter:
-
     def __init__(self, metadata: Dict):
         self.file_path: str = metadata['output_file_path']
-        overwrite: bool = metadata.get('overwrite', True)
+        overwrite: bool = metadata.get('overwrite', False)
         exists = os.path.exists(self.file_path)
         self.mode = 'w' if overwrite else 'a'
         self.has_header = overwrite or not exists
@@ -84,10 +86,9 @@ class CsvWriter:
 
 
 class JsonlWriter:
-
     def __init__(self, metadata: Dict):
         self.file_path: str = metadata['output_file_path']
-        overwrite: bool = metadata.get('overwrite', True)
+        overwrite: bool = metadata.get('overwrite', False)
         self.mode = 'w' if overwrite else 'a'
 
     def __call__(self, data: List):


### PR DESCRIPTION
- introduced locks for iterators
- avoids attribute error when passing a bad reader/writer name