### PR TITLE
Output registry

### DIFF
--- a/app.py
+++ b/app.py
@@ -86,7 +86,6 @@ def scramble(job_name: str, metadata: Dict, reader_name: str,
     except PermissionError as e:
         logging.error(e)
         raise HTTPException(status_code=400, detail=str(e))
-    print(OUTPUT_REGISTRY)
     if not force_overwrite and writer and writer.file_path in OUTPUT_REGISTRY:
         msg = f'Output path not allowed `{writer.file_path}`.'
         raise HTTPException(status_code=400, detail=msg)

--- a/app.py
+++ b/app.py
@@ -19,6 +19,8 @@ app = FastAPI()
 
 logging.info(util.blue('PLANCHET IS STARTING!'))
 
+OUTPUT_REGISTRY = set()
+
 
 def _load_jobs(ledger) -> Dict:
     jobs: Dict = {}
@@ -26,6 +28,7 @@ def _load_jobs(ledger) -> Dict:
         job_name: str = job_key.decode('utf8').split(':', 1)[1]
         try:
             jobs[job_name] = Job.restore_job(job_name, job_key, ledger)
+            OUTPUT_REGISTRY.add(jobs[job_name].writer.file_path)
         except json.JSONDecodeError:
             logging.error(f'Could not restore job: {job_key}')
         except FileNotFoundError as e:
@@ -54,7 +57,8 @@ except ConnectionError:
 @app.post("/scramble")
 def scramble(job_name: str, metadata: Dict, reader_name: str,
              writer_name: str, clean_start: bool = False,
-             mode: str = READ_WRITE, cont: bool = False):
+             mode: str = READ_WRITE, cont: bool = False,
+             force_overwrite: bool = False):
     """
     Start a new job.
 
@@ -65,6 +69,7 @@ def scramble(job_name: str, metadata: Dict, reader_name: str,
     :param clean_start: clean the items before you start
     :param mode: I/O mode
     :param cont: start a repair job
+    :param force_overwrite: force overwrite of the
     """
     logging.info(util.pink(
         f'SCRAMBLING: name->{job_name}; metadata->{metadata}; '
@@ -81,6 +86,10 @@ def scramble(job_name: str, metadata: Dict, reader_name: str,
     except PermissionError as e:
         logging.error(e)
         raise HTTPException(status_code=400, detail=str(e))
+    print(OUTPUT_REGISTRY)
+    if not force_overwrite and writer and writer.file_path in OUTPUT_REGISTRY:
+        msg = f'Output path not allowed `{writer.file_path}`.'
+        raise HTTPException(status_code=400, detail=msg)
     existing_job = LEDGER.get(f'JOB:{job_name}')
     # trying to re-create an existing job
     if existing_job and (not clean_start and not cont):
@@ -97,6 +106,8 @@ def scramble(job_name: str, metadata: Dict, reader_name: str,
     if clean_start:
         new_job.restart()
     JOB_LOG[job_name] = new_job
+    if writer:
+        OUTPUT_REGISTRY.add(writer.file_path)
     # TODO: move this in a method inside the Job class and call here
     LEDGER.set(f'JOB:{job_name}', json.dumps({
         'metadata': metadata, 'reader_name': reader_name,
@@ -199,6 +210,7 @@ def clean(job_name: str, output: bool = True):
         raise HTTPException(400, msg)
     try:
         job.clean(output=output)
+        OUTPUT_REGISTRY.discard(job.writer.file_path)
     except FileNotFoundError:
         msg = f'Could not find a output file for job "{job_name}"'
         logging.info(util.pink(msg))
@@ -219,6 +231,7 @@ def purge(output: bool = False):
     for name, job in list(JOB_LOG.items()):
         job.clean(output)
         del JOB_LOG[name]
+        OUTPUT_REGISTRY.discard(job.writer.file_path)
 
 
 @app.get("/report")

--- a/planchet/io.py
+++ b/planchet/io.py
@@ -107,7 +107,10 @@ class CsvWriter:
         self.has_header = overwrite or not exists
 
     def clean(self):
-        os.remove(self.file_path)
+        try:
+            os.remove(self.file_path)
+        except FileNotFoundError:
+            pass
 
     def __call__(self, data: List):
         if not data:
@@ -133,7 +136,10 @@ class JsonlWriter:
         self.mode = 'w' if overwrite else 'a'
 
     def clean(self):
-        os.remove(self.file_path)
+        try:
+            os.remove(self.file_path)
+        except FileNotFoundError:
+            pass
 
     def __call__(self, data: List):
         with open(self.file_path, mode=self.mode) as fh:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,5 @@
 import os
+import random
 
 from fastapi.testclient import TestClient
 import pytest
@@ -24,7 +25,8 @@ def job_params():
         'job_name': TEST_JOB_NAME,
         'reader_name': 'CsvReader',
         'writer_name': 'CsvWriter',
-        'clean_start': 'false'
+        'clean_start': 'false',
+        'force_overwrite': 'true'
     }
 
 
@@ -46,9 +48,9 @@ def input_fp_client(data):
     os.remove(fp)
 
 
-@pytest.fixture()
+@pytest.fixture(scope='function')
 def output_fp():
-    fp = 'output_file.csv'
+    fp = f'output_file.{str(random.randint(0, 1000))}.csv'
     yield fp
     try:
         os.remove(fp)
@@ -58,7 +60,7 @@ def output_fp():
 
 @pytest.fixture()
 def output_fp_client():
-    fp = '/data/client_output_file.csv'
+    fp = f'/data/client_output_file.{str(random.randint(0, 1000))}.csv'
     yield fp
     try:
         os.remove(fp)
@@ -126,7 +128,7 @@ def reader(input_fp):
     return CsvReader(metadata)
 
 
-@pytest.fixture()
+@pytest.fixture(scope='function')
 def writer(output_fp):
     metadata = {'output_file_path': output_fp}
     return CsvWriter(metadata)

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -336,7 +336,7 @@ def test_output_registry(client, job_params, metadata):
     )
     response = client.get(f'/report?job_name={TEST_JOB_NAME}')
     assert response.status_code == 200, response.text
-    job_params['job_name'] = 'new_original_job_1234'
+    job_params['job_name'] = 'new_original_job_12342345345'
     param_string = _make_param_string(job_params)
     response = client.post(
         f'/scramble?{param_string}',
@@ -344,7 +344,7 @@ def test_output_registry(client, job_params, metadata):
     )
     assert response.status_code == 400, 'Output registry did not block creating a new job'
     client.get(f'/purge')
-    job_params['job_name'] = 'new_original_job_986'
+    job_params['job_name'] = 'new_original_job_98693458'
     param_string = _make_param_string(job_params)
     response = client.post(
         f'/scramble?{param_string}',

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -330,7 +330,6 @@ def test_purge(client, job_params, metadata, output):
 def test_output_registry(client, job_params, metadata):
     job_params['force_overwrite'] = False
     param_string = _make_param_string(job_params)
-    print(metadata)
     client.post(
         f'/scramble?{param_string}',
         json=metadata


### PR DESCRIPTION
- output registry blocking new jobs outputting in the same file
- `force_overwrite` parameter to override the register

Closes #30 